### PR TITLE
feat(watcher): accept poll flag for polling file system changes

### DIFF
--- a/commands/Serve.ts
+++ b/commands/Serve.ts
@@ -24,6 +24,15 @@ export default class Serve extends BaseCommand {
   public watch: boolean
 
   /**
+   * Detect changes by polling files
+   */
+  @flags.boolean({
+    description: 'Detect file changes by polling files instead of listening to filesystem events',
+    alias: 'p',
+  })
+  public poll: boolean
+
+  /**
    * Allows watching for file changes
    */
   @flags.boolean({
@@ -73,9 +82,9 @@ export default class Serve extends BaseCommand {
 
     try {
       if (this.compile === false) {
-        await new BuildWatcher(cwd, this.nodeArgs, this.logger).watch(ADONIS_BUILD_DIR() || './')
+        await new BuildWatcher(cwd, this.nodeArgs, this.logger).watch(ADONIS_BUILD_DIR() || './', this.poll)
       } else if (this.watch) {
-        await new Watcher(cwd, true, this.nodeArgs, this.logger).watch()
+        await new Watcher(cwd, true, this.nodeArgs, this.logger).watch(this.poll)
       } else {
         await new Compiler(cwd, true, this.nodeArgs, this.logger).compile()
       }

--- a/src/BuildWatcher/index.ts
+++ b/src/BuildWatcher/index.ts
@@ -41,7 +41,7 @@ export class BuildWatcher {
   /**
    * Watch for compiled output changes
    */
-  public async watch (buildDir: string) {
+  public async watch (buildDir: string, poll = false) {
     const absPath = join(this.buildRoot, buildDir)
     const hasBuildDir = await pathExists(absPath)
     if (!hasBuildDir) {
@@ -58,6 +58,7 @@ export class BuildWatcher {
      */
     const watcher = chokidar.watch(['.'], {
       ignoreInitial: true,
+      usePolling: poll,
       cwd: absPath,
       ignored: [
         'node_modules/**',

--- a/src/Watcher/index.ts
+++ b/src/Watcher/index.ts
@@ -38,7 +38,7 @@ export class Watcher {
   /**
    * Build and watch for file changes
    */
-  public async watch () {
+  public async watch (poll = false) {
     const config = this.compiler.parseConfig()
     if (!config) {
       return
@@ -205,6 +205,7 @@ export class Watcher {
      */
     watcher.watch(['.'], {
       ignored: config.raw.exclude,
+      usePolling: poll,
     })
   }
 }

--- a/src/Watcher/index.ts
+++ b/src/Watcher/index.ts
@@ -204,10 +204,7 @@ export class Watcher {
      * Start the watcher
      */
     watcher.watch(['.'], {
-      ignored: [
-        'node_modules/**',
-        `${config.options.outDir}/**`,
-      ],
+      ignored: config.raw.exclude,
     })
   }
 }


### PR DESCRIPTION
Make watcher respect excluded directories set in configuration file

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Right now watcher does not care about excluded directories set in tsconfig.json file, since it has hardcoded values to ignore node_modules and build destination.
This PR will fix it and make watcher read exclude list from config

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/git@github.com/adonisjs/blob/assembler.git/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Configuration has three identical arrays that all would work for it:
`config.configFileSpecs.excludeSpecs`
`config.configFileSpecs.validatedExcludeSpecs`
and 
`config.raw.exclude`

Used the last one since this was only one that didn't throw TS error (`config.configFileSpecs` does not exist according to TS), but I'm unsure if this is the best one to use.