### PR TITLE
fix: remove import-fresh dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "fs-extra": "^9.1.0",
     "get-port": "^5.1.1",
     "has-yarn": "^2.1.0",
-    "import-fresh": "^3.3.0",
     "picomatch": "^2.2.2",
     "slash": "^3.0.0"
   },

--- a/src/RcFile/index.ts
+++ b/src/RcFile/index.ts
@@ -10,7 +10,7 @@
 import slash from 'slash'
 import picomatch from 'picomatch'
 import { join, relative } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Application } from '@adonisjs/application'
 import { resolveFrom } from '@poppinss/utils/build/helpers'
 
@@ -100,10 +100,10 @@ export class RcFile {
   }
 
   /**
-   * Reloads the rcfile.json bypassing the require cache
+   * Reloads the rcfile.json
    */
   public getDiskContents(): any {
-    return importFresh(this.rcFilePath) as any
+    return readJSONSync(this.rcFilePath)
   }
 
   /**

--- a/test/make-command.spec.ts
+++ b/test/make-command.spec.ts
@@ -10,7 +10,7 @@
 import test from 'japa'
 import { join } from 'path'
 import { Kernel } from '@adonisjs/ace'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
 
@@ -36,7 +36,7 @@ test.group('Make Command', (group) => {
   test('make a command inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const command = new MakeCommand(app, new Kernel(app))
@@ -66,7 +66,7 @@ test.group('Make Command', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const command = new MakeCommand(app, new Kernel(app))
@@ -96,7 +96,7 @@ test.group('Make Command', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const command = new MakeCommand(app, new Kernel(app))

--- a/test/make-controller.spec.ts
+++ b/test/make-controller.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -36,7 +36,7 @@ test.group('Make Controller', (group) => {
   test('make a controller inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const controller = new MakeController(app, new Kernel(app))
@@ -54,7 +54,7 @@ test.group('Make Controller', (group) => {
   test('make a resourceful controller inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const controller = new MakeController(app, new Kernel(app))
@@ -83,7 +83,7 @@ test.group('Make Controller', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const controller = new MakeController(app, new Kernel(app))

--- a/test/make-exception.spec.ts
+++ b/test/make-exception.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -36,7 +36,7 @@ test.group('Make Exception', (group) => {
   test('make an exception class inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const exception = new MakeException(app, new Kernel(app))
@@ -56,7 +56,7 @@ test.group('Make Exception', (group) => {
   test('make a self-handled exception class inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const exception = new MakeException(app, new Kernel(app))
@@ -87,7 +87,7 @@ test.group('Make Exception', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const exception = new MakeException(app, new Kernel(app))

--- a/test/make-listener.spec.ts
+++ b/test/make-listener.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -36,7 +36,7 @@ test.group('Make Listener', (group) => {
   test('make a listener inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const listener = new MakeListener(app, new Kernel(app))
@@ -64,7 +64,7 @@ test.group('Make Listener', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const listener = new MakeListener(app, new Kernel(app))

--- a/test/make-middleware.spec.ts
+++ b/test/make-middleware.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -36,7 +36,7 @@ test.group('Make Middleware', (group) => {
   test('make a middleware inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const middleware = new MakeMiddleware(app, new Kernel(app))

--- a/test/make-preloaded-file.spec.ts
+++ b/test/make-preloaded-file.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -36,7 +36,7 @@ test.group('Make Preloaded File', (group) => {
   test('make a preload file inside the start directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const preloadFile = new PreloadFile(app, new Kernel(app))
@@ -69,7 +69,7 @@ test.group('Make Preloaded File', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const preloadFile = new PreloadFile(app, new Kernel(app))
@@ -96,7 +96,7 @@ test.group('Make Preloaded File', (group) => {
   test('select environment as repl', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const preloadFile = new PreloadFile(app, new Kernel(app))
@@ -122,7 +122,7 @@ test.group('Make Preloaded File', (group) => {
   test('prompt for environment when not explicitly defined', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const preloadFile = new PreloadFile(app, new Kernel(app))

--- a/test/make-provider.spec.ts
+++ b/test/make-provider.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -36,7 +36,7 @@ test.group('Make Provider', (group) => {
   test('make a provider inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const provider = new MakeProvider(app, new Kernel(app))
@@ -66,7 +66,7 @@ test.group('Make Provider', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const provider = new MakeProvider(app, new Kernel(app))
@@ -92,7 +92,7 @@ test.group('Make Provider', (group) => {
   test('setup correct path when nested provider is created', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const provider = new MakeProvider(app, new Kernel(app))
@@ -115,7 +115,7 @@ test.group('Make Provider', (group) => {
   test('make ace provider', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const provider = new MakeProvider(app, new Kernel(app))

--- a/test/make-validator.spec.ts
+++ b/test/make-validator.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -36,7 +36,7 @@ test.group('Make Validator', (group) => {
   test('make a model inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const validator = new MakeValidator(app, new Kernel(app))
@@ -66,7 +66,7 @@ test.group('Make Validator', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const validator = new MakeValidator(app, new Kernel(app))

--- a/test/make-view.spec.ts
+++ b/test/make-view.spec.ts
@@ -9,7 +9,7 @@
 
 import test from 'japa'
 import { join } from 'path'
-import importFresh from 'import-fresh'
+import { readJSONSync } from 'fs-extra'
 import { Kernel } from '@adonisjs/ace'
 import { Filesystem } from '@poppinss/dev-utils'
 import { Application } from '@adonisjs/application'
@@ -34,7 +34,7 @@ test.group('Make Command', (group) => {
   test('make an empty view inside the default directory', async (assert) => {
     await fs.add('.adonisrc.json', JSON.stringify({}))
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const view = new MakeView(app, new Kernel(app))
@@ -55,7 +55,7 @@ test.group('Make Command', (group) => {
       })
     )
 
-    const rcContents = importFresh(join(fs.basePath, '.adonisrc.json')) as any
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
     const app = new Application(fs.basePath, 'test', rcContents)
 
     const view = new MakeView(app, new Kernel(app))


### PR DESCRIPTION
It is used to bypass the require cache, but this is not necessary as we
can just read the JSON files using fs-extra.
`import-fresh` uses a deprecated Node.js API. This is why I suggest to remove it.

Refs: https://nodejs.org/dist/latest-v15.x/docs/api/deprecations.html#DEP0144

