### PR TITLE
feat: add support for --tsconfig build flag

### DIFF
--- a/commands/Build.ts
+++ b/commands/Build.ts
@@ -9,6 +9,7 @@
 
 import hasYarn from 'has-yarn'
 import { BaseCommand, flags } from '@adonisjs/core/build/standalone'
+import { TSCONFIG_FILE_NAME } from '../config/paths'
 
 /**
  * Compile typescript project Javascript
@@ -41,6 +42,15 @@ export default class Build extends BaseCommand {
     description: 'Ignore typescript errors and complete the build process',
   })
   public ignoreTsErrors: boolean
+
+  /**
+   * Path to the TypeScript project configuration file. Defaults to "tsconfig.json"
+   */
+  @flags.string({
+    description: 'Path to the TypeScript project configuration file',
+    default: TSCONFIG_FILE_NAME,
+  })
+  public tsconfig: string
 
   /**
    * Arguments to pass to the `encore` binary
@@ -84,14 +94,16 @@ export default class Build extends BaseCommand {
           this.application.appRoot,
           this.encoreArgs,
           this.assets,
-          this.logger
+          this.logger,
+          this.tsconfig
         ).compileForProduction(stopOnError, this.client)
       } else {
         await new Compiler(
           this.application.appRoot,
           this.encoreArgs,
           this.assets,
-          this.logger
+          this.logger,
+          this.tsconfig
         ).compile(stopOnError)
       }
     } catch (error) {

--- a/src/Compiler/index.ts
+++ b/src/Compiler/index.ts
@@ -29,7 +29,7 @@ export class Compiler {
   /**
    * Reference to typescript compiler
    */
-  private ts = new Ts(this.appRoot, this.logger)
+  private ts: Ts
 
   /**
    * Reference to rc File
@@ -40,8 +40,10 @@ export class Compiler {
     public appRoot: string,
     private encoreArgs: string[],
     private buildAssets: boolean,
-    private logger: typeof uiLogger = uiLogger
+    private logger: typeof uiLogger = uiLogger,
+    tsconfig?: string
   ) {
+    this.ts = new Ts(this.appRoot, this.logger, tsconfig)
     this.ts.tsCompiler.use(() => {
       return iocTransformer(this.ts.tsCompiler.ts, this.rcFile.application.rcFile)
     }, 'after')

--- a/src/Ts/index.ts
+++ b/src/Ts/index.ts
@@ -24,11 +24,15 @@ export class Ts {
    */
   public tsCompiler = new TypescriptCompiler(
     this.appRoot,
-    TSCONFIG_FILE_NAME,
+    this.tsconfig,
     require(resolveFrom(this.appRoot, 'typescript/lib/typescript'))
   )
 
-  constructor(private appRoot: string, private logger: typeof uiLogger) {}
+  constructor(
+    private appRoot: string,
+    private logger: typeof uiLogger,
+    private tsconfig = TSCONFIG_FILE_NAME
+  ) {}
 
   /**
    * Render ts diagnostics
@@ -44,13 +48,13 @@ export class Ts {
     const { error, config } = this.tsCompiler.configParser().parse()
 
     if (error) {
-      this.logger.error(`unable to parse ${TSCONFIG_FILE_NAME}`)
+      this.logger.error(`unable to parse ${this.tsconfig}`)
       this.renderDiagnostics([error], this.tsCompiler.ts.createCompilerHost({}))
       return
     }
 
     if (config && config.errors.length) {
-      this.logger.error(`unable to parse ${TSCONFIG_FILE_NAME}`)
+      this.logger.error(`unable to parse ${this.tsconfig}`)
       this.renderDiagnostics(config.errors, this.tsCompiler.ts.createCompilerHost(config.options))
       return
     }


### PR DESCRIPTION
This allows to specify a different tsconfig file for the production
build. For example, that file can extend the main tsconfig.json to
ignore test files.
