### PR TITLE
refactor: simplify generate:manifest error handling

### DIFF
--- a/src/Manifest/index.ts
+++ b/src/Manifest/index.ts
@@ -59,20 +59,6 @@ export class Manifest {
       })
 
       /**
-       * Print warning when `stderr` exists
-       */
-      if (response.stderr) {
-        if (this.isMalformedJSONError(response.stderr) && this.attempts < this.maxAttempts) {
-          this.attempts++
-          return this.generate()
-        }
-
-        this.logger.warning(WARN_MESSAGE)
-        this.logger.logError(response.stderr)
-        return false
-      }
-
-      /**
        * Log success
        */
       if (response.stdout) {

--- a/test/compiler.spec.ts
+++ b/test/compiler.spec.ts
@@ -606,7 +606,7 @@ test.group('Compiler', (group) => {
     assert.isTrue(hasPackageLock)
   }).timeout(0)
 
-  test('gracefully log error when ace file writes to stderr', async (assert) => {
+  test('gracefully log error when ace file finishes with non-zero exit code', async (assert) => {
     await fs.add(
       '.adonisrc.json',
       JSON.stringify({
@@ -624,7 +624,7 @@ test.group('Compiler', (group) => {
       })
     )
 
-    await fs.add('ace', "console.error('foo')")
+    await fs.add('ace', "console.error('foo');process.exit(1)")
     await fs.add('src/foo.ts', '')
     await fs.add('public/styles/main.css', '')
     await fs.add('public/scripts/main.js', '')


### PR DESCRIPTION
Now that Ace correctly exits with code 1 on error, there is no need to
check stderr. This also prevents us from interpreting output from
deprecation warnings as manifest generation errors.
