### PR TITLE
Webpack dev server not beeing killed by CTRL+C in Windows

### DIFF
--- a/src/AssetsBundler/index.ts
+++ b/src/AssetsBundler/index.ts
@@ -32,6 +32,7 @@ export class AssetsBundler extends Emittery {
     stdio: 'pipe' as const,
     localDir: this.projectRoot,
     cwd: this.projectRoot,
+    windowsHide: false,
     env: {
       FORCE_COLOR: 'true',
       ...this.env,


### PR DESCRIPTION
## Proposed changes

Killing server with CTRL-C in dev mode in Windows leaves webpack-dev-server running on port 8080 and
never releases it, making it impossible to start up again with `node ace serve -w` because port 8080 is already in use.

Have to use `Get-Process -Id (Get-NetTCPConnection -LocalPort 8080).OwningProcess` to find the proccess ID and then kill it with `Stop-Process -ID ID_HERE -Force`

Fixes https://github.com/adonisjs/core/issues/2562

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/assembler/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)