### PR TITLE
feat: use default suffix when making listeners

### DIFF
--- a/commands/Make/Listener.ts
+++ b/commands/Make/Listener.ts
@@ -18,6 +18,7 @@ export default class MakeListener extends BaseGenerator {
   /**
    * Required by BaseGenerator
    */
+  protected suffix = 'Listener'
   protected form = 'singular' as const
   protected pattern = 'pascalcase' as const
   protected resourceName: string

--- a/test/make-listener.spec.ts
+++ b/test/make-listener.spec.ts
@@ -43,11 +43,11 @@ test.group('Make Listener', (group) => {
     listener.name = 'user'
     await listener.run()
 
-    const UserListener = await fs.get('app/Listeners/User.ts')
+    const UserListener = await fs.get('app/Listeners/UserListener.ts')
     const ListenerTemplate = await templates.get('event-listener.txt')
     assert.deepEqual(
       toNewlineArray(UserListener),
-      toNewlineArray(ListenerTemplate.replace('{{ filename }}', 'User'))
+      toNewlineArray(ListenerTemplate.replace('{{ filename }}', 'UserListener'))
     )
   })
 
@@ -71,11 +71,11 @@ test.group('Make Listener', (group) => {
     listener.name = 'user'
     await listener.run()
 
-    const UserListener = await fs.get('app/Events/Listeners/User.ts')
+    const UserListener = await fs.get('app/Events/Listeners/UserListener.ts')
     const ListenerTemplate = await templates.get('event-listener.txt')
     assert.deepEqual(
       toNewlineArray(UserListener),
-      toNewlineArray(ListenerTemplate.replace('{{ filename }}', 'User'))
+      toNewlineArray(ListenerTemplate.replace('{{ filename }}', 'UserListener'))
     )
   })
 })


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Put a suffix for listener classes generated by the `make:listener` command. It's the default behavior for controllers and validators. I was having problems when importing models in the listener file, I can use `as` but it seems better to me to open this pull request.

## Types of changes


_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/assembler/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments
