### PR TITLE
fix: avoid Api getting pluralized

### DIFF
--- a/commands/Make/Controller.ts
+++ b/commands/Make/Controller.ts
@@ -35,6 +35,7 @@ export default class MakeController extends BaseGenerator {
     'Adonis',
     'Dashboard',
     'Signup',
+    'Api',
   ]
 
   /**


### PR DESCRIPTION
## Proposed changes

This PR adds `Api` to the `formIgnoreList` array to avoid controllers named `Api` being pluralized. This changes comes after a [request on the Discord server](https://discord.com/channels/423256550564691970/434251922934071296/930831394551246858).

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/assembler/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I haven't seen any tests or documentation related to this, let me know if there is something missing.
