### PR TITLE
refactor(templates): use import type when possible

### DIFF
--- a/templates/controller.txt
+++ b/templates/controller.txt
@@ -1,3 +1,3 @@
-// import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+// import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
 export default class {{ filename }} {}

--- a/templates/event-listener.txt
+++ b/templates/event-listener.txt
@@ -1,3 +1,3 @@
-import { EventsList } from '@ioc:Adonis/Core/Event'
+import type { EventsList } from '@ioc:Adonis/Core/Event'
 
 export default class {{ filename }} {}

--- a/templates/middleware.txt
+++ b/templates/middleware.txt
@@ -1,4 +1,4 @@
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
 export default class {{ filename }} {
   public async handle({}: HttpContextContract, next: () => Promise<void>) {

--- a/templates/provider.txt
+++ b/templates/provider.txt
@@ -1,4 +1,4 @@
-import { ApplicationContract } from '@ioc:Adonis/Core/Application'
+import type { ApplicationContract } from '@ioc:Adonis/Core/Application'
 
 /*
 |--------------------------------------------------------------------------

--- a/templates/resource-controller.txt
+++ b/templates/resource-controller.txt
@@ -1,4 +1,4 @@
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
 export default class {{ filename }} {
   public async index({}: HttpContextContract) {}

--- a/templates/self-handle-exception.txt
+++ b/templates/self-handle-exception.txt
@@ -1,5 +1,5 @@
 import { Exception } from '@adonisjs/core/build/standalone'
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
 /*
 |--------------------------------------------------------------------------

--- a/templates/validator.txt
+++ b/templates/validator.txt
@@ -1,5 +1,5 @@
 import { schema } from '@ioc:Adonis/Core/Validator'
-import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
 
 export default class {{ filename }} {
   constructor(protected ctx: HttpContextContract) {}


### PR DESCRIPTION
Hey! 👋🏻 

Since TypeScript 3.8 we can use `import type` instead of `import` for anything only type related.

> `import type` only imports declarations to be used for type annotations and declarations. It **always** gets fully erased, so there’s no remnant of it at runtime. Similarly, `export type` only provides an export that can be used for type contexts, and is also erased from TypeScript’s output.