### PR TITLE
fix: array filters passed to TestProcess were not processed properly

### DIFF
--- a/src/Test/process.ts
+++ b/src/Test/process.ts
@@ -40,12 +40,14 @@ export class TestProcess {
     const filters = Object.keys(this.filters).reduce<string[]>((result, filter) => {
       const value = this.filters[filter]
 
-      if (filter !== '_') {
-        result.push(filter)
+      if (filter === '_') {
+        result.push(...value)
+        return result
       }
 
+      result.push(filter)
       if (Array.isArray(value)) {
-        result.push(...value)
+        result.push(value.join(','))
       } else {
         result.push(value)
       }


### PR DESCRIPTION
For example, the following command : 
`node ace test --tags=tag1,tag2 --timeout 600 unit`
Produced the following error: 
`Unrecognized suite "tag2". Make sure to define it in the config first`

If I did a console.log of `filters` that was passed to execa, then I got this result 
`[ '--timeout', 60, '--tags', 'tag1, 'tag2', 'unit' ]`

So I redid a pass on the filters processing and everything seems to work fine.
I will migrate to the latest version of Japa and add some tests on this in the next PR.