### PR TITLE
feat: add `make:factory` command

### DIFF
--- a/commands/Make/Factory.ts
+++ b/commands/Make/Factory.ts
@@ -1,0 +1,108 @@
+/*
+ * @adonisjs/assembler
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { join } from 'path'
+import { args, flags } from '@adonisjs/core/build/standalone'
+import { BaseGenerator } from './Base'
+
+/**
+ * Command to make a new Factory
+ */
+export default class MakeFactory extends BaseGenerator {
+  /**
+   * Required by BaseGenerator
+   */
+  protected suffix = 'Factory'
+  protected pattern = 'pascalcase' as const
+  protected resourceName: string
+  protected createExact: boolean
+
+  /**
+   * Command meta data
+   */
+  public static commandName = 'make:factory'
+  public static description = 'Make a new factory'
+
+  /**
+   * Name of the model to be used in the factory
+   */
+  @args.string({ description: 'The name of the model' })
+  public model: string
+
+  /**
+   * Import path to the model used in the factory
+   */
+  @flags.string({ description: 'The path to the model' })
+  public modelPath: string
+
+  @flags.boolean({
+    description: 'Create the factory with the exact name as provided',
+    alias: 'e',
+  })
+  public exact: boolean
+
+  /**
+   * Generate model import path used in the factory
+   */
+  private generateModelImportPath() {
+    let base = this.application.rcFile.namespaces.models || 'App/Models'
+    if (!base.endsWith('/')) {
+      base += '/'
+    }
+
+    let importPath = this.model
+    if (this.modelPath) {
+      importPath = this.modelPath
+    } else if (importPath.endsWith('Factory')) {
+      importPath = importPath.replace(/Factory$/, '')
+    }
+
+    if (importPath.startsWith(base)) {
+      return importPath
+    }
+
+    return base + importPath
+  }
+
+  /**
+   * Returns the template stub path
+   */
+  protected getStub() {
+    return join(__dirname, '..', '..', 'templates', 'factory.txt')
+  }
+
+  /**
+   * Path to the factories directory
+   */
+  protected getDestinationPath() {
+    const base = this.application.rcFile.directories.database || 'database'
+    return join(base, 'factories')
+  }
+
+  /**
+   * Passed down to the stub template
+   */
+  protected templateData() {
+    return {
+      model: this.model,
+      modelImportPath: this.generateModelImportPath(),
+      toModelName: () => {
+        return function (model: string, render: any) {
+          return render(model).split('/').pop()
+        }
+      },
+    }
+  }
+
+  public async run() {
+    this.resourceName = this.model
+    this.createExact = this.exact
+    await super.generate()
+  }
+}

--- a/templates/factory.txt
+++ b/templates/factory.txt
@@ -1,0 +1,8 @@
+import {{#toModelName}}{{{ model }}}{{/toModelName}} from '{{{ modelImportPath }}}'
+import Factory from '@ioc:Adonis/Lucid/Factory'
+
+export default Factory.define({{#toModelName}}{{{ model }}}{{/toModelName}}, ({ faker }) => {
+  return {
+    //
+  }
+})

--- a/test-helpers/index.ts
+++ b/test-helpers/index.ts
@@ -11,6 +11,14 @@ export function toNewlineArray(contents: string): string[] {
   return contents.split(/\r?\n/)
 }
 
+export function replaceFactoryBindings(source: string, model: string, importPath: string) {
+  return toNewlineArray(
+    source
+      .replace('{{{ modelImportPath }}}', importPath)
+      .replace(/{{#toModelName}}{{{ model }}}{{\/toModelName}}/gi, model)
+  )
+}
+
 export const info = '[ blue(info) ]'
 export const success = '[ green(success) ]'
 export const error = '[ red(error) ]'

--- a/test/make-factory.spec.ts
+++ b/test/make-factory.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * @adonisjs/assembler
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { test } from '@japa/runner'
+import { join } from 'path'
+import { Kernel } from '@adonisjs/ace'
+import { readJSONSync } from 'fs-extra'
+import { Filesystem } from '@poppinss/dev-utils'
+import { Application } from '@adonisjs/application'
+import { replaceFactoryBindings, toNewlineArray } from '../test-helpers'
+import MakeFactory from '../commands/Make/Factory'
+import { ApplicationContract } from '@ioc:Adonis/Core/Application'
+
+const fs = new Filesystem(join(__dirname, '__app'))
+const templates = new Filesystem(join(__dirname, '..', 'templates'))
+
+test.group('Make Factory', async (group) => {
+  let app: ApplicationContract
+
+  group.each.setup(async () => {
+    await fs.add('.adonisrc.json', JSON.stringify({}))
+    const rcContents = readJSONSync(join(fs.basePath, '.adonisrc.json'))
+    app = new Application(fs.basePath, 'test', rcContents)
+
+    process.env.ADONIS_ACE_CWD = fs.basePath
+
+    return async () => {
+      process.env.ADONIS_ACE_CWD = fs.basePath
+      await fs.cleanup()
+    }
+  })
+
+  test('generate a factory for {model}')
+    .with([
+      {
+        argument: 'User',
+        model: 'User',
+        finalDestination: 'UserFactory.ts',
+        finalImportPath: 'App/Models/User',
+      },
+      {
+        argument: 'Blog/Post',
+        model: 'Post',
+        finalDestination: 'Blog/PostFactory.ts',
+        finalImportPath: 'App/Models/Blog/Post',
+      },
+    ])
+    .run(async ({ assert }, set) => {
+      const factory = new MakeFactory(app, new Kernel(app).mockConsoleOutput())
+
+      factory.model = set.argument
+      await factory.run()
+
+      const UserFactory = await fs.get(`database/factories/${set.finalDestination}`)
+      const factoryTemplate = await templates.get('factory.txt')
+
+      assert.deepEqual(
+        toNewlineArray(UserFactory),
+        replaceFactoryBindings(factoryTemplate, set.model, set.finalImportPath)
+      )
+    })
+
+  test('generate a factory with custom import path')
+    .with([
+      {
+        argument: 'User',
+        model: 'User',
+        modelPath: 'Test/User',
+        finalDestination: 'UserFactory.ts',
+        finalImportPath: 'App/Models/Test/User',
+      },
+      {
+        argument: 'Client',
+        model: 'Client',
+        modelPath: 'App/Models/Test/B/Client',
+        finalDestination: 'ClientFactory.ts',
+        finalImportPath: 'App/Models/Test/B/Client',
+      },
+    ])
+    .run(async ({ assert }, set) => {
+      const factory = new MakeFactory(app, new Kernel(app).mockConsoleOutput())
+
+      factory.model = set.model
+      factory.modelPath = set.modelPath
+
+      await factory.run()
+
+      const UserFactory = await fs.get(`database/factories/${set.finalDestination}`)
+      const factoryTemplate = await templates.get('factory.txt')
+
+      assert.deepEqual(
+        toNewlineArray(UserFactory),
+        replaceFactoryBindings(factoryTemplate, set.model, set.finalImportPath)
+      )
+    })
+})


### PR DESCRIPTION
## Proposed changes

Adds the `make:factory` command.

```bash
Usage: make:factory <model>

Arguments
  model                The name of the model

Flags
  --model-path string  The path to the model
  -e, --exact boolean  Create the factory with the exact name as provided 
```

--- 

`node ace make:factory Client` gives : 

Destination : `database/factories/ClientFactory.ts`
```ts
import Client from 'App/Models/Client'
import Factory from '@ioc:Adonis/Lucid/Factory'

export default Factory.define(Client, ({ faker }) => {
  return {
    //
  }
})
```

In the case of a nested model ( let's stay Client model is stored in App/Models/Feature/Client, then :
`node ace make:factory Feature/Client` gives :

Destination: `database/factories/ClientFactory.ts`
```ts
import Client from 'App/Models/Test/Client'
import Factory from '@ioc:Adonis/Lucid/Factory'
...
```
---

The import path to the model used in the top of the factory stub can be customized using the `--model-path` flag :

`node ace make:factory ClientFactory --model-path=My/Nested/Model/Client`
or
`node ace make:factory ClientFactory --model-path=App/Models/My/Nested/Model/Client`

Gives: 
```ts
import Client from 'App/Models/My/Nested/Model/Client'
import Factory from '@ioc:Adonis/Lucid/Factory'
....
````

---

I had some doubts about using a fast-glob system to search for the model in the App/Models sub-folders in order to automatically determine the import path in the case where we have either particular factory names or models sorted in a particular way. I finally decided not to, but if you think it's necessary, let me know
