### PR TITLE
fix: incorrect test/bootstrap.txt typing

### DIFF
--- a/templates/tests/bootstrap.txt
+++ b/templates/tests/bootstrap.txt
@@ -20,7 +20,7 @@ import { assert, runFailedTests, specReporter, apiClient } from '@japa/preset-ad
 | Feel free to remove existing plugins or add more.
 |
 */
-export const plugins: Config['plugins'] = [assert(), runFailedTests(), apiClient()]
+export const plugins: Required<Config>['plugins'] = [assert(), runFailedTests(), apiClient()]
 
 /*
 |--------------------------------------------------------------------------
@@ -32,7 +32,7 @@ export const plugins: Config['plugins'] = [assert(), runFailedTests(), apiClient
 | of tests on the terminal.
 |
 */
-export const reporters: Config['reporters'] = [specReporter()]
+export const reporters: Required<Config>['reporters'] = [specReporter()]
 
 /*
 |--------------------------------------------------------------------------
@@ -46,7 +46,7 @@ export const reporters: Config['reporters'] = [specReporter()]
 | within the runner hooks
 |
 */
-export const runnerHooks: Required<Pick<Config, 'setup' | 'teardown'>> = {
+export const runnerHooks: Pick<Required<Config>, 'setup' | 'teardown'> = {
   setup: [() => TestUtils.ace().loadCommands()],
   teardown: [],
 }
@@ -62,7 +62,7 @@ export const runnerHooks: Required<Pick<Config, 'setup' | 'teardown'>> = {
 | You can use this method to configure suites. For example: Only start
 | the HTTP server when it is a functional suite.
 */
-export const configureSuite: Config['configureSuite'] = (suite) => {
+export const configureSuite: Required<Config>['configureSuite'] = (suite) => {
   if (suite.name === 'functional') {
     suite.setup(() => TestUtils.httpServer().start())
   }


### PR DESCRIPTION
When strict mode was enabled, the types for the different values exported in bootstrap.txt template were incorrect : 

![image](https://user-images.githubusercontent.com/8337858/196997510-81e5fdd8-e854-48bd-a72d-c509ce527129.png)

For example, type of `export const reporters` was `ReporterContract[] | undefined`. 