### PR TITLE
fix: metafiles copying

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "pretest": "npm run lint",
-    "test": "cross-env NODE_DEBUG=chokidar:ts c8 npm run vscode:test",
+    "test": "cross-env NODE_DEBUG=chokidar:ts c8 npm run quick:test",
     "lint": "eslint . --ext=.ts",
     "clean": "del-cli build",
     "compile": "npm run lint && npm run clean && tsc",
@@ -28,7 +28,7 @@
     "sync-labels": "github-label-sync --labels .github/labels.json adonisjs/assembler",
     "format": "prettier --write .",
     "prepublishOnly": "npm run build",
-    "vscode:test": "node --loader=ts-node/esm bin/test.ts"
+    "quick:test": "node --loader=ts-node/esm bin/test.ts"
   },
   "keywords": [
     "adonisjs",
@@ -67,7 +67,7 @@
     "@poppinss/chokidar-ts": "^4.1.0-3",
     "@poppinss/cliui": "^6.1.1-2",
     "@types/picomatch": "^2.3.0",
-    "cpy": "^9.0.1",
+    "cpy": "^8.1.2",
     "execa": "^7.0.0",
     "get-port": "^6.1.2",
     "picomatch": "^2.3.1",

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -101,7 +101,7 @@ export class Bundler {
    */
   async #copyFiles(files: string[], outDir: string) {
     try {
-      await copyfiles(files, outDir, { cwd: this.#cwdPath })
+      await copyfiles(files, outDir, { parents: true, cwd: this.#cwdPath })
     } catch (error) {
       if (!error.message.includes("the file doesn't exist")) {
         throw error

--- a/tests/bundler.spec.ts
+++ b/tests/bundler.spec.ts
@@ -5,7 +5,10 @@ import ts from 'typescript'
 test.group('Bundler', () => {
   test('should copy metafiles to the build directory', async ({ assert, fs }) => {
     await Promise.all([
-      fs.create('tsconfig.json', JSON.stringify({ compilerOptions: { outDir: 'build' } })),
+      fs.create(
+        'tsconfig.json',
+        JSON.stringify({ compilerOptions: { outDir: 'build', skipLibCheck: true } })
+      ),
       fs.create('.adonisrc.json', '{}'),
       fs.create('package.json', '{}'),
       fs.create('package-lock.json', '{}'),

--- a/tests/bundler.spec.ts
+++ b/tests/bundler.spec.ts
@@ -1,0 +1,41 @@
+import { test } from '@japa/runner'
+import { Bundler } from '../index.js'
+import ts from 'typescript'
+
+test.group('Bundler', () => {
+  test('should copy metafiles to the build directory', async ({ assert, fs }) => {
+    await Promise.all([
+      fs.create('tsconfig.json', JSON.stringify({ compilerOptions: { outDir: 'build' } })),
+      fs.create('.adonisrc.json', '{}'),
+      fs.create('package.json', '{}'),
+      fs.create('package-lock.json', '{}'),
+
+      fs.create('resources/js/app.ts', ''),
+      fs.create('resources/views/app.edge', ''),
+      fs.create('resources/views/foo.edge', ''),
+      fs.create('resources/views/nested/bar.edge', ''),
+      fs.create('resources/views/nested/baz.edge', ''),
+    ])
+
+    const bundler = new Bundler(fs.baseUrl, ts, {
+      metaFiles: [
+        {
+          pattern: 'resources/views/**/*.edge',
+          reloadServer: false,
+        },
+      ],
+    })
+
+    await bundler.bundle(true, 'npm')
+
+    await Promise.all([
+      assert.fileExists('./build/resources/views/app.edge'),
+      assert.fileExists('./build/resources/views/foo.edge'),
+      assert.fileExists('./build/resources/views/nested/bar.edge'),
+      assert.fileExists('./build/resources/views/nested/baz.edge'),
+      assert.fileExists('./build/.adonisrc.json'),
+      assert.fileExists('./build/package.json'),
+      assert.fileExists('./build/package-lock.json'),
+    ])
+  })
+})


### PR DESCRIPTION
As you saw, cpy has had some breaking changes and they've changed their APIs. So if we follow their changelog, then you seem to have made the change the right way. 
However, it seems to doesn't work as expected :

For a metaFiles pattern `/resources/views/**.*.edge` and the given directory structure : 
```
  resources/
    views/
       view.edge
        admin/
            admin.edge
```

After copying, we will have this result in the ./build folder:

```
build/
  view.edge
  admin/
    admin.edge
```

I don't know why, I've tried a lot of different things to make it works but I think that it's a bug on the cpy side. so I suggest we just rollback temporarily. not super important I think

Also added a test that check we keep the original directory structure 