### PR TITLE
fix(transformer): addCommand method was not using correct property name

### DIFF
--- a/src/code_transformer/rc_file_transformer.ts
+++ b/src/code_transformer/rc_file_transformer.ts
@@ -172,7 +172,7 @@ export class RcFileTransformer {
    * Add a new command to the rcFile
    */
   addCommand(commandPath: string) {
-    const commandsProperty = this.#getPropertyAssignmentInDefineConfigCall('providers', '[]')
+    const commandsProperty = this.#getPropertyAssignmentInDefineConfigCall('commands', '[]')
     const commandsArray = commandsProperty.getInitializerIfKindOrThrow(
       SyntaxKind.ArrayLiteralExpression
     )


### PR DESCRIPTION
Hey there! 👋🏻 

This PR is fixing an issue with the `addCommand` method. We were not using the correct property name.

We will have to revisit our test suites since that kinds of errors are currently not caught.