### PR TITLE
Add `addJapaPlugin` to Codemods

### DIFF
--- a/src/code_transformer/main.ts
+++ b/src/code_transformer/main.ts
@@ -9,7 +9,7 @@
 
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { CodeBlockWriter, Node, Project, SourceFile, SyntaxKind } from 'ts-morph'
+import { CodeBlockWriter, Node, Project, QuoteKind, SourceFile, SyntaxKind } from 'ts-morph'
 
 import { RcFileTransformer } from './rc_file_transformer.js'
 import type { AddMiddlewareEntry, EnvValidationDefinition } from '../types.js'
@@ -41,6 +41,7 @@ export class CodeTransformer {
     this.#cwd = cwd
     this.#project = new Project({
       tsConfigFilePath: join(fileURLToPath(this.#cwd), 'tsconfig.json'),
+      manipulationSettings: { quoteKind: QuoteKind.Single },
     })
   }
 

--- a/src/code_transformer/main.ts
+++ b/src/code_transformer/main.ts
@@ -9,7 +9,15 @@
 
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { CodeBlockWriter, Node, Project, QuoteKind, SourceFile, SyntaxKind } from 'ts-morph'
+import {
+  CodeBlockWriter,
+  FormatCodeSettings,
+  Node,
+  Project,
+  QuoteKind,
+  SourceFile,
+  SyntaxKind,
+} from 'ts-morph'
 
 import { RcFileTransformer } from './rc_file_transformer.js'
 import type { AddMiddlewareEntry, EnvValidationDefinition } from '../types.js'
@@ -31,10 +39,12 @@ export class CodeTransformer {
   /**
    * Settings to use when persisting files
    */
-  #editorSettings = {
+  #editorSettings: FormatCodeSettings = {
     indentSize: 2,
     convertTabsToSpaces: true,
     trimTrailingWhitespace: true,
+    // @ts-expect-error SemicolonPreference doesn't seem to be re-exported from ts-morph
+    semicolons: 'remove',
   }
 
   constructor(cwd: URL) {

--- a/src/code_transformer/main.ts
+++ b/src/code_transformer/main.ts
@@ -178,6 +178,42 @@ export class CodeTransformer {
   }
 
   /**
+   * Add a new Japa plugin in the `tests/bootstrap.ts` file
+   */
+  async addJapaPlugin(
+    pluginCall: string,
+    importDeclaration: { isNamed: boolean; module: string; identifier: string }
+  ) {
+    /**
+     * Get the `tests/bootstrap.ts` source file
+     */
+    const testBootstrapUrl = fileURLToPath(new URL('./tests/bootstrap.ts', this.#cwd))
+    const file = this.#project.getSourceFileOrThrow(testBootstrapUrl)
+
+    /**
+     * Add the import declaration
+     */
+    file.addImportDeclaration({
+      ...(importDeclaration.isNamed
+        ? { namedImports: [importDeclaration.identifier] }
+        : { defaultImport: importDeclaration.identifier }),
+      moduleSpecifier: importDeclaration.module,
+    })
+
+    /**
+     * Insert the plugin call in the `plugins` array
+     */
+    const pluginsArray = file
+      .getVariableDeclaration('plugins')
+      ?.getInitializerIfKind(SyntaxKind.ArrayLiteralExpression)
+
+    if (pluginsArray) pluginsArray.addElement(pluginCall)
+
+    file.formatText(this.#editorSettings)
+    await file.save()
+  }
+
+  /**
    * Add new env variable validation in the
    * `env.ts` file
    */

--- a/tests/__snapshots__/code_transformer.spec.ts.cjs
+++ b/tests/__snapshots__/code_transformer.spec.ts.cjs
@@ -357,7 +357,7 @@ export default defineConfig({
 exports[`Code transformer | addPreloadFile > addJapaPlugin should works fine 1`] = `"
 import app from '@adonisjs/core/services/app'
 import { assert } from '@japa/assert'
-import { fooPlugin } from '@adonisjs/foo/plugin/japa';
+import { fooPlugin } from '@adonisjs/foo/plugin/japa'
 
 export const plugins: Config['plugins'] = [
   assert(),

--- a/tests/__snapshots__/code_transformer.spec.ts.cjs
+++ b/tests/__snapshots__/code_transformer.spec.ts.cjs
@@ -354,3 +354,14 @@ export default defineConfig({
 })
 "`
 
+exports[`Code transformer | addPreloadFile > addJapaPlugin should works fine 1`] = `"
+import app from '@adonisjs/core/services/app'
+import { assert } from '@japa/assert'
+import { fooPlugin } from \\"@adonisjs/foo/plugin/japa\\";
+
+export const plugins: Config['plugins'] = [
+  assert(),
+  fooPlugin(app)
+]
+"`
+

--- a/tests/__snapshots__/code_transformer.spec.ts.cjs
+++ b/tests/__snapshots__/code_transformer.spec.ts.cjs
@@ -354,7 +354,7 @@ export default defineConfig({
 })
 "`
 
-exports[`Code transformer | addPreloadFile > addJapaPlugin should works fine 1`] = `"
+exports[`Code transformer | addJapaPlugin > addJapaPlugin with named import 1`] = `"
 import app from '@adonisjs/core/services/app'
 import { assert } from '@japa/assert'
 import { fooPlugin } from '@adonisjs/foo/plugin/japa'
@@ -362,6 +362,17 @@ import { fooPlugin } from '@adonisjs/foo/plugin/japa'
 export const plugins: Config['plugins'] = [
   assert(),
   fooPlugin(app)
+]
+"`
+
+exports[`Code transformer | addJapaPlugin > addJapaPlugin with default import 1`] = `"
+import app from '@adonisjs/core/services/app'
+import { assert } from '@japa/assert'
+import fooPlugin from '@adonisjs/foo/plugin/japa'
+
+export const plugins: Config['plugins'] = [
+  assert(),
+  fooPlugin()
 ]
 "`
 

--- a/tests/__snapshots__/code_transformer.spec.ts.cjs
+++ b/tests/__snapshots__/code_transformer.spec.ts.cjs
@@ -357,7 +357,7 @@ export default defineConfig({
 exports[`Code transformer | addPreloadFile > addJapaPlugin should works fine 1`] = `"
 import app from '@adonisjs/core/services/app'
 import { assert } from '@japa/assert'
-import { fooPlugin } from \\"@adonisjs/foo/plugin/japa\\";
+import { fooPlugin } from '@adonisjs/foo/plugin/japa';
 
 export const plugins: Config['plugins'] = [
   assert(),

--- a/tests/code_transformer.spec.ts
+++ b/tests/code_transformer.spec.ts
@@ -505,4 +505,28 @@ test.group('Code transformer | addPreloadFile', (group) => {
 
     assert.equal(occurrences, 1)
   })
+
+  test('addJapaPlugin should works fine', async ({ assert, fs }) => {
+    await fs.create(
+      'tests/bootstrap.ts',
+      `
+      import app from '@adonisjs/core/services/app'
+      import { assert } from '@japa/assert'
+
+      export const plugins: Config['plugins'] = [
+        assert(),
+      ]`
+    )
+
+    const transformer = new CodeTransformer(fs.baseUrl)
+
+    await transformer.addJapaPlugin('fooPlugin(app)', {
+      module: '@adonisjs/foo/plugin/japa',
+      identifier: 'fooPlugin',
+      isNamed: true,
+    })
+
+    const file = await fs.contents('tests/bootstrap.ts')
+    assert.snapshot(file).match()
+  })
 })

--- a/tests/code_transformer.spec.ts
+++ b/tests/code_transformer.spec.ts
@@ -505,8 +505,12 @@ test.group('Code transformer | addPreloadFile', (group) => {
 
     assert.equal(occurrences, 1)
   })
+})
 
-  test('addJapaPlugin should works fine', async ({ assert, fs }) => {
+test.group('Code transformer | addJapaPlugin', (group) => {
+  group.each.setup(async ({ context }) => setupFakeAdonisproject(context.fs))
+
+  test('addJapaPlugin with named import', async ({ assert, fs }) => {
     await fs.create(
       'tests/bootstrap.ts',
       `
@@ -524,6 +528,30 @@ test.group('Code transformer | addPreloadFile', (group) => {
       module: '@adonisjs/foo/plugin/japa',
       identifier: 'fooPlugin',
       isNamed: true,
+    })
+
+    const file = await fs.contents('tests/bootstrap.ts')
+    assert.snapshot(file).match()
+  })
+
+  test('addJapaPlugin with default import', async ({ assert, fs }) => {
+    await fs.create(
+      'tests/bootstrap.ts',
+      `
+      import app from '@adonisjs/core/services/app'
+      import { assert } from '@japa/assert'
+
+      export const plugins: Config['plugins'] = [
+        assert(),
+      ]`
+    )
+
+    const transformer = new CodeTransformer(fs.baseUrl)
+
+    await transformer.addJapaPlugin('fooPlugin()', {
+      module: '@adonisjs/foo/plugin/japa',
+      identifier: 'fooPlugin',
+      isNamed: false,
     })
 
     const file = await fs.contents('tests/bootstrap.ts')

--- a/tests/code_transformer.spec.ts
+++ b/tests/code_transformer.spec.ts
@@ -510,7 +510,7 @@ test.group('Code transformer | addPreloadFile', (group) => {
 test.group('Code transformer | addJapaPlugin', (group) => {
   group.each.setup(async ({ context }) => setupFakeAdonisproject(context.fs))
 
-  test('addJapaPlugin with named import', async ({ assert, fs }) => {
+  test('add named import', async ({ assert, fs }) => {
     await fs.create(
       'tests/bootstrap.ts',
       `
@@ -534,7 +534,7 @@ test.group('Code transformer | addJapaPlugin', (group) => {
     assert.snapshot(file).match()
   })
 
-  test('addJapaPlugin with default import', async ({ assert, fs }) => {
+  test('add default import', async ({ assert, fs }) => {
     await fs.create(
       'tests/bootstrap.ts',
       `


### PR DESCRIPTION
`addJapaPlugin` will modify the `boostrap/tests.ts` file to add a new plugin to the `export const plugins` array.

Can be used as follows: 

```ts
await codemods.addJapaPlugin('sessionApiClient(app)', {
  module: '@adonisjs/session/plugins/api_client',
  identifier: 'sessionApiClient',
  isNamed: true,
})
```

The first parameter is the text to be inserted into the array of plugins
The second parameter is the import to add to the top of the file. This can be a named import or not.

The above code will result in : 

```ts
import app from '@adonisjs/core/services/app'
import { assert } from '@japa/assert'
import { sessionApiClient } from '@adonisjs/session/plugins/api_client'

export const plugins: Config['plugins'] = [
  assert(),
  sessionApiClient(app)
]
```

Also added two settings for all transformation done with ts-morph : Use single quote instead of doubles, and also remove semicolons with `formatText`