### PR TITLE
Bundler automatically detect used package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@adonisjs/env": "^4.2.0-7",
+    "@antfu/install-pkg": "^0.2.0",
     "@poppinss/chokidar-ts": "^4.1.1",
     "@poppinss/cliui": "^6.2.1",
     "cpy": "^11.0.0",

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -20,7 +20,6 @@ import { run, parseConfig, copyFiles } from './helpers.js'
 
 type SupportedPackageManager = 'npm' | 'yarn' | 'pnpm'
 
-
 /**
  * Instance of CLIUI
  */
@@ -128,11 +127,10 @@ export class Bundler {
       pnpm: {
         lockFile: 'pnpm-lock.yaml',
         installCommand: 'pnpm i --prod',
-      }
+      },
     }
 
-
-    const pkgManager = client || await detectPackageManager(this.#cwdPath) || 'npm'
+    const pkgManager = client || (await detectPackageManager(this.#cwdPath)) || 'npm'
     if (!['npm', 'yarn', 'pnpm'].includes(pkgManager)) {
       throw new Error(`Unsupported package manager "${pkgManager}"`)
     }
@@ -151,10 +149,7 @@ export class Bundler {
   /**
    * Bundles the application to be run in production
    */
-  async bundle(
-    stopOnError: boolean = true,
-    client?: SupportedPackageManager
-  ): Promise<boolean> {
+  async bundle(stopOnError: boolean = true, client?: SupportedPackageManager): Promise<boolean> {
     /**
      * Step 1: Parse config file to get the build output directory
      */
@@ -211,7 +206,7 @@ export class Bundler {
     /**
      * Step 5: Copy meta files to the build directory
      */
-    const pkgManager  = await this.#getPackageManager(client)
+    const pkgManager = await this.#getPackageManager(client)
     const pkgFiles = ['package.json', pkgManager.lockFile]
     this.#logger.info('copying meta files to the output directory')
     await this.#copyMetaFiles(outDir, pkgFiles)

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -13,9 +13,13 @@ import { relative } from 'node:path'
 import type tsStatic from 'typescript'
 import { fileURLToPath } from 'node:url'
 import { cliui, type Logger } from '@poppinss/cliui'
+import { detectPackageManager } from '@antfu/install-pkg'
 
 import type { BundlerOptions } from './types.js'
 import { run, parseConfig, copyFiles } from './helpers.js'
+
+type SupportedPackageManager = 'npm' | 'yarn' | 'pnpm'
+
 
 /**
  * Instance of CLIUI
@@ -107,31 +111,33 @@ export class Bundler {
   }
 
   /**
-   * Returns the lock file name for a given packages client
+   * Detect the package manager used by the project
+   * and return the lockfile name and install command
+   * related to it.
    */
-  #getClientLockFile(client: 'npm' | 'yarn' | 'pnpm') {
-    switch (client) {
-      case 'npm':
-        return 'package-lock.json'
-      case 'yarn':
-        return 'yarn.lock'
-      case 'pnpm':
-        return 'pnpm-lock.yaml'
+  async #getPackageManager(client?: SupportedPackageManager) {
+    const pkgManagerInfo = {
+      npm: {
+        lockFile: 'package-lock.json',
+        installCommand: 'npm ci --omit="dev"',
+      },
+      yarn: {
+        lockFile: 'yarn.lock',
+        installCommand: 'yarn install --production',
+      },
+      pnpm: {
+        lockFile: 'pnpm-lock.yaml',
+        installCommand: 'pnpm i --prod',
+      }
     }
-  }
 
-  /**
-   * Returns the installation command for a given packages client
-   */
-  #getClientInstallCommand(client: 'npm' | 'yarn' | 'pnpm') {
-    switch (client) {
-      case 'npm':
-        return 'npm ci --omit="dev"'
-      case 'yarn':
-        return 'yarn install --production'
-      case 'pnpm':
-        return 'pnpm i --prod'
+
+    const pkgManager = client || await detectPackageManager(this.#cwdPath) || 'npm'
+    if (!['npm', 'yarn', 'pnpm'].includes(pkgManager)) {
+      throw new Error(`Unsupported package manager "${pkgManager}"`)
     }
+
+    return pkgManagerInfo[pkgManager as SupportedPackageManager]
   }
 
   /**
@@ -147,7 +153,7 @@ export class Bundler {
    */
   async bundle(
     stopOnError: boolean = true,
-    client: 'npm' | 'yarn' | 'pnpm' = 'npm'
+    client?: SupportedPackageManager
   ): Promise<boolean> {
     /**
      * Step 1: Parse config file to get the build output directory
@@ -205,7 +211,8 @@ export class Bundler {
     /**
      * Step 5: Copy meta files to the build directory
      */
-    const pkgFiles = ['package.json', this.#getClientLockFile(client)]
+    const pkgManager  = await this.#getPackageManager(client)
+    const pkgFiles = ['package.json', pkgManager.lockFile]
     this.#logger.info('copying meta files to the output directory')
     await this.#copyMetaFiles(outDir, pkgFiles)
 
@@ -219,7 +226,7 @@ export class Bundler {
       .useRenderer(this.#logger.getRenderer())
       .heading('Run the following commands to start the server in production')
       .add(this.#colors.cyan(`cd ${this.#getRelativeName(outDir)}`))
-      .add(this.#colors.cyan(this.#getClientInstallCommand(client)))
+      .add(this.#colors.cyan(pkgManager.installCommand))
       .add(this.#colors.cyan('node bin/server.js'))
       .render()
 

--- a/tests/bundler.spec.ts
+++ b/tests/bundler.spec.ts
@@ -71,4 +71,60 @@ test.group('Bundler', () => {
       assert.fileExists('./build/adonisrc.js'),
     ])
   })
+
+  test('use npm by default if not specified', async ({ assert, fs }) => {
+    await Promise.all([
+      fs.create(
+        'tsconfig.json',
+        JSON.stringify({ compilerOptions: { outDir: 'build', skipLibCheck: true } })
+      ),
+      fs.create('adonisrc.ts', 'export default {}'),
+      fs.create('package.json', '{}'),
+      fs.create('package-lock.json', '{}'),
+    ])
+
+    const bundler = new Bundler(fs.baseUrl, ts, {
+      metaFiles: [
+        {
+          pattern: 'resources/views/**/*.edge',
+          reloadServer: false,
+        },
+      ],
+    })
+
+    await bundler.bundle(true)
+
+    await Promise.all([
+      assert.fileExists('./build/package.json'),
+      assert.fileExists('./build/package-lock.json'),
+    ])
+  })
+
+  test('detect package manager if not specified', async ({ assert, fs }) => {
+    await Promise.all([
+      fs.create(
+        'tsconfig.json',
+        JSON.stringify({ compilerOptions: { outDir: 'build', skipLibCheck: true } })
+      ),
+      fs.create('adonisrc.ts', 'export default {}'),
+      fs.create('package.json', '{}'),
+      fs.create('pnpm-lock.yaml', '{}'),
+    ])
+
+    const bundler = new Bundler(fs.baseUrl, ts, {
+      metaFiles: [
+        {
+          pattern: 'resources/views/**/*.edge',
+          reloadServer: false,
+        },
+      ],
+    })
+
+    await bundler.bundle(true)
+
+    await Promise.all([
+      assert.fileExists('./build/package.json'),
+      assert.fileExists('./build/pnpm-lock.yaml'),
+    ])
+  })
 })


### PR DESCRIPTION
Port of this PR to the assembler : https://github.com/adonisjs/core/pull/4290

Bundler will automatically detect the package manager used by the project, if not specified explicitly