### PR TITLE
change: sigkill --> sigterm to allow graceful shutdowns

### DIFF
--- a/src/assets_dev_server.ts
+++ b/src/assets_dev_server.ts
@@ -175,7 +175,7 @@ export class AssetsDevServer {
   stop() {
     if (this.#devServer) {
       this.#devServer.removeAllListeners()
-      this.#devServer.kill('SIGKILL')
+      this.#devServer.kill('SIGTERM')
       this.#devServer = undefined
     }
   }

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -216,7 +216,7 @@ export class DevServer {
   #restartHTTPServer(port: string) {
     if (this.#httpServer) {
       this.#httpServer.removeAllListeners()
-      this.#httpServer.kill('SIGKILL')
+      this.#httpServer.kill('SIGTERM')
     }
 
     this.#startHTTPServer(port, 'blocking')
@@ -292,7 +292,7 @@ export class DevServer {
     this.#assetsServer?.stop()
     if (this.#httpServer) {
       this.#httpServer.removeAllListeners()
-      this.#httpServer.kill('SIGKILL')
+      this.#httpServer.kill('SIGTERM')
     }
   }
 

--- a/src/test_runner.ts
+++ b/src/test_runner.ts
@@ -258,7 +258,7 @@ export class TestRunner {
   #rerunTests(port: string, filters?: TestRunnerOptions['filters']) {
     if (this.#testScript) {
       this.#testScript.removeAllListeners()
-      this.#testScript.kill('SIGKILL')
+      this.#testScript.kill('SIGTERM')
     }
 
     this.#runTests(port, 'blocking', filters)
@@ -349,7 +349,7 @@ export class TestRunner {
     this.#assetsServer?.stop()
     if (this.#testScript) {
       this.#testScript.removeAllListeners()
-      this.#testScript.kill('SIGKILL')
+      this.#testScript.kill('SIGTERM')
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

I've started a proposal on discord: https://discord.com/channels/423256550564691970/1216131764410650674/1216131764410650674

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This changes all instances of `SIGKILL` to `SIGTERM` when killing processes. This allows the child processes to gracefully shutdown. In adonis, this means that the `ServiceProvider`'s have their `shutdown` handlers invoked. With `SIGKILL`, I've noticed that the `ServiceProvider.shutdown` handler is never invoked.

To give context as to why this is an issue for me, my application needs the `ServiceProvider.shutdown` handler invoked in order to be successfully started back up. I have puppeteer running from within my adonis app, which spawns a child process for chromium. Puppeteer/chromium has logic in place to ensure that only one process is ever running (they use `tmp` dir for this). I need to kill this process before my app can restart successfully. I currently handle this via a `ServiceProvider.shutdown` hook. With `SIGTERM`, this handler is invoked, with `SIGKILL`, it is not.

Is there a specific reason I may be overlooking that `SIGKILL` was explicitly chosen? If so, please let me know and I'll close this and add in some "hacks" to my application boot to do this cleanup.

---------

I wasn't sure how to test this. I didn't notice any existing tests around this functionality. I would be happy to add some, but I need some guidance! 

What I did test was changing `SIGKILL` to `SIGTERM` on the v5.9.5 tag here: https://github.com/adonisjs/assembler/blob/9cfd8180f75948ded60171c446638b5fb6b3b23f/src/HttpServer/index.ts#L83 

My app successfully reboots in `node ace serve --watch` with this change.

**So I did not test these proposed changes on `develop`, as I don't have an app running adonis v6/assemblerv7!**

I would really like this fixed in adonis v5 / assembler v5, but I wasn't sure of the current branching strategy to support that.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
