### PR TITLE
feat: hot-hook integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "del-cli": "^5.1.0",
     "eslint": "^8.57.0",
     "github-label-sync": "^2.3.1",
+    "hot-hook": "^0.1.9",
     "husky": "^9.0.11",
     "np": "^10.0.2",
     "p-event": "^6.0.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,11 @@ export type AssetsBundlerOptions =
  */
 export type DevServerOptions = {
   /**
+   * If the dev server should use HMR
+   */
+  hmr?: boolean
+
+  /**
    * Arguments to pass to the "bin/server.js" file
    * executed a child process
    */


### PR DESCRIPTION
Integrate hot-hook into the assembler

Basically, if the --hmr flag is passed, we spawn the Node subprocess with the `--import=hot-hook/register` hook.
We intercept received messages sent by Hot Hook from the subprocess: 
- If it's a full reload message, clear screen + log + restart http server
- If it's an invalidation message (i.e. from HMR), then just a log