### PR TITLE
refactor: update ready message

### DIFF
--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -210,11 +210,9 @@ export class DevServer {
           .useColors(this.#colors)
           .useRenderer(this.#logger.getRenderer())
           .add(`Server address: ${this.#colors.cyan(`http://${host}:${message.port}`)}`)
-          .add(
-            `File system watcher: ${this.#colors.cyan(
-              `${this.#isWatching ? 'enabled' : 'disabled'}`
-            )}`
-          )
+
+        const watchMode = this.#options.hmr ? 'HMR' : this.#isWatching ? 'Watching' : 'Non-Watching'
+        displayMessage.add(`Mode: ${this.#colors.cyan(watchMode)}`)
 
         if (message.duration) {
           displayMessage.add(`Ready in: ${this.#colors.cyan(prettyHrtime(message.duration))}`)

--- a/src/dev_server.ts
+++ b/src/dev_server.ts
@@ -211,8 +211,8 @@ export class DevServer {
           .useRenderer(this.#logger.getRenderer())
           .add(`Server address: ${this.#colors.cyan(`http://${host}:${message.port}`)}`)
 
-        const watchMode = this.#options.hmr ? 'HMR' : this.#isWatching ? 'Watching' : 'Non-Watching'
-        displayMessage.add(`Mode: ${this.#colors.cyan(watchMode)}`)
+        const watchMode = this.#options.hmr ? 'HMR' : this.#isWatching ? 'Legacy' : 'None'
+        displayMessage.add(`Watch Mode: ${this.#colors.cyan(watchMode)}`)
 
         if (message.duration) {
           displayMessage.add(`Ready in: ${this.#colors.cyan(prettyHrtime(message.duration))}`)

--- a/tests/run.spec.ts
+++ b/tests/run.spec.ts
@@ -60,7 +60,7 @@ test.group('Child process', () => {
     const childProcess = runNode(fs.basePath, {
       script: 'foo.ts',
       scriptArgs: ['--watch', '--foo=bar'],
-      nodeArgs: ['--throw-deprecation'],
+      nodeArgs: ['--conditions=dev'],
     })
 
     const payload = await pEvent(childProcess, 'message', { rejectionEvents: ['error'] })
@@ -74,7 +74,7 @@ test.group('Child process', () => {
         process.allowedNodeEnvironmentFlags.has('--disable-warning')
           ? '--disable-warning=ExperimentalWarning'
           : '--no-warnings',
-        '--throw-deprecation',
+        '--conditions=dev',
       ],
     })
   })


### PR DESCRIPTION
The `file system watcher` message that appears when you start the Adonis server is no longer really appropriate now that we have HMR. Because we have a `File System Watcher: disabled` which is displayed when we are in HMR mode. 

![image](https://github.com/adonisjs/assembler/assets/8337858/349e4bdf-a42f-4089-a870-fb8081a724e0)

Looks weird


So I've changed the message. But not really sure of the words :

- With nothing, it will display `Mode: Non-Watching`.
- `--watch` will display: `Mode: Watching`
- `--hmr` will display: `Mode: HMR`

![image](https://github.com/adonisjs/assembler/assets/8337858/a698e1dd-9a24-4d6d-9159-972109ce09d6)


if you guys have something better lemme know