### PR TITLE
feat: yarn berry support

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -41,7 +41,7 @@ const SUPPORT_PACKAGE_MANAGERS: {
     installCommand: 'yarn install --production',
   },
   'yarn@berry': {
-    packageManagerFiles: ['yarn.lock', '.yarn/**/*'],
+    packageManagerFiles: ['yarn.lock', '.yarn/**/*', '.yarnrc.yml'],
     installCommand: 'yarn workspaces focus --production',
   },
   'pnpm': {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

[adonisjs/core#4568](https://github.com/adonisjs/core/issues/4568)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for yarn berry into assembler (required to then add it to core).
It replaces `lockFile` in `SUPPORT_PACKAGE_MANAGERS` because yarn berry also need some other metadata files, but it might be useful for other package managers too.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Not sure there is documentation to be updated, it should just make it work out of the box for yarn berry.
