### PR TITLE
The build directory can be missing, create it if it doesn't exist

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -189,6 +189,10 @@ export class Bundler {
       await import('./bin/console.js')
     `)
 
+    /**
+     *  <project>/build directory may not exist
+     */
+    await fs.mkdir(outDir, { recursive: true })
     await fs.writeFile(aceFileLocation, aceFileContent)
     this.#logger.info('created ace file', { suffix: this.#getRelativeName(aceFileLocation) })
   }


### PR DESCRIPTION
See this thread in the discord:
https://discord.com/channels/423256550564691970/1335384583205818452

tl;dr: it's possible for the build directory to be missing, 
and createAceFile requires that it exists today.

Since that guarantee can't be made, we can create the directory if it's missing.


However, in a new project, I haven't been able to re-create the situation yet
- delete build directory
- run build
  - new project: everything is fine
  - my project: error from the discord thread 

However, I patch-package'd my repo with this fix, and I'm back in business