### PR TITLE
feat: add raw assembler hooks and imports to rcFile

### DIFF
--- a/src/code_transformer/rc_file_transformer.ts
+++ b/src/code_transformer/rc_file_transformer.ts
@@ -440,12 +440,18 @@ export default defineConfig({
 
   /**
    * Add a new assembler hook
+   * The format `thunk` write `() => import(path)`.
    *
    * @param type - The type of hook to add
-   * @param path - The path to the hook file
+   * @param value - The path to the hook file or value to write
+   * @param raw - Wether to write a thunk import or as raw value
    * @returns This RcFileTransformer instance for method chaining
    */
-  addAssemblerHook(type: keyof Exclude<AssemblerRcFile['hooks'], undefined>, path: string) {
+  addAssemblerHook(
+    type: keyof Exclude<AssemblerRcFile['hooks'], undefined>,
+    value: string,
+    raw: boolean = false
+  ) {
     const hooksProperty = this.#getPropertyAssignmentInDefineConfigCall('hooks', '{}')
 
     const hooks = hooksProperty.getInitializerIfKindOrThrow(SyntaxKind.ObjectLiteralExpression)
@@ -456,12 +462,53 @@ export default defineConfig({
     }
 
     const hooksArray = hookArray.getInitializerIfKindOrThrow(SyntaxKind.ArrayLiteralExpression)
-    const existingHooks = this.#extractModulesFromArray(hooksArray)
-    if (existingHooks.includes(path)) {
-      return this
+
+    if (raw) {
+      hooksArray.addElement(value)
+    } else {
+      const existingHooks = this.#extractModulesFromArray(hooksArray)
+      if (existingHooks.includes(value)) {
+        return this
+      }
+
+      hooksArray.addElement(`() => import('${value}')`)
     }
 
-    hooksArray.addElement(`() => import('${path}')`)
+    return this
+  }
+
+  /**
+   * Add a named import
+   *
+   * @param specifier - The module specifier to import
+   * @param names - Names to import from the module
+   * @returns This RcFileTransformer instance for method chaining
+   */
+  addNamedImport(specifier: string, names: string[]) {
+    const file = this.#getRcFileOrThrow()
+
+    file.addImportDeclaration({
+      moduleSpecifier: specifier,
+      namedImports: names,
+    })
+
+    return this
+  }
+
+  /**
+   * Add a default import
+   *
+   * @param specifier - The module specifier to import
+   * @param name - Name of the default import
+   * @returns This RcFileTransformer instance for method chaining
+   */
+  addDefaultImport(specifier: string, name: string) {
+    const file = this.#getRcFileOrThrow()
+
+    file.addImportDeclaration({
+      moduleSpecifier: specifier,
+      defaultImport: name,
+    })
 
     return this
   }

--- a/src/types/code_transformer.ts
+++ b/src/types/code_transformer.ts
@@ -106,6 +106,17 @@ export type EnvValidationNode = {
   variables: Record<string, string>
 }
 
+export type HookNode =
+  | {
+      type: 'thunk'
+      path: string
+    }
+  | {
+      type: 'import'
+      path: string
+      name?: string
+    }
+
 /**
  * The supported package managers for installing packages and managing lockfiles.
  * Each package manager has specific lockfiles and install commands.

--- a/tests/__snapshots__/code_transformer.spec.ts.cjs
+++ b/tests/__snapshots__/code_transformer.spec.ts.cjs
@@ -431,3 +431,98 @@ export default defineConfig({
 })
 "`
 
+exports[`Code Transformer | addAssemblerHook > add raw assembler hook to the assembler file 1`] = `"import { defineConfig } from '@adonisjs/core/app'
+
+export default defineConfig({
+  typescript: true,
+  preloads: [
+    () => import('./start/routes.ts'),
+    {
+      file: () => import('./start/ace.ts'),
+      environment: ['console'],
+    },
+  ],
+  providers: [
+    () => import('@adonisjs/core/providers/app_provider'),
+    {
+      file: () => import('@adonisjs/core/providers/repl_provider'),
+      environment: ['repl'],
+    }
+  ],
+  metaFiles: [
+    {
+      pattern: 'public/**',
+      reloadServer: true
+    },
+  ],
+  commands: [
+    () => import('@adonisjs/core/commands')
+  ],
+  hooks: {
+    init: [indexPages()]
+  }
+})
+"`
+
+exports[`Code Transformer | addDefaultImport > add default import to the assembler file 1`] = `"import { defineConfig } from '@adonisjs/core/app'
+import indexPages from '@adonisjs/inertia'
+
+export default defineConfig({
+  typescript: true,
+  preloads: [
+    () => import('./start/routes.ts'),
+    {
+      file: () => import('./start/ace.ts'),
+      environment: ['console'],
+    },
+  ],
+  providers: [
+    () => import('@adonisjs/core/providers/app_provider'),
+    {
+      file: () => import('@adonisjs/core/providers/repl_provider'),
+      environment: ['repl'],
+    }
+  ],
+  metaFiles: [
+    {
+      pattern: 'public/**',
+      reloadServer: true
+    },
+  ],
+  commands: [
+    () => import('@adonisjs/core/commands')
+  ]
+})
+"`
+
+exports[`Code Transformer | addNamedImport > add named import to the assembler file 1`] = `"import { defineConfig } from '@adonisjs/core/app'
+import { indexPages } from '@adonisjs/inertia'
+
+export default defineConfig({
+  typescript: true,
+  preloads: [
+    () => import('./start/routes.ts'),
+    {
+      file: () => import('./start/ace.ts'),
+      environment: ['console'],
+    },
+  ],
+  providers: [
+    () => import('@adonisjs/core/providers/app_provider'),
+    {
+      file: () => import('@adonisjs/core/providers/repl_provider'),
+      environment: ['repl'],
+    }
+  ],
+  metaFiles: [
+    {
+      pattern: 'public/**',
+      reloadServer: true
+    },
+  ],
+  commands: [
+    () => import('@adonisjs/core/commands')
+  ]
+})
+"`
+

--- a/tests/code_transformer.spec.ts
+++ b/tests/code_transformer.spec.ts
@@ -1284,4 +1284,45 @@ test.group('Code Transformer | addAssemblerHook', (group) => {
 
     assert.equal(occurrences, 1)
   })
+
+  test('add raw assembler hook to the assembler file', async ({ assert, fs }) => {
+    const transformer = new CodeTransformer(fs.baseUrl)
+
+    await transformer.updateRcFile((rcFile) =>
+      rcFile.addAssemblerHook('init', 'indexPages()', true)
+    )
+
+    const file = await fs.contents('adonisrc.ts')
+    assert.snapshot(file).match()
+  })
+})
+
+test.group('Code Transformer | addDefaultImport', (group) => {
+  group.each.setup(async ({ context }) => setupFakeAdonisproject(context.fs))
+
+  test('add default import to the assembler file', async ({ assert, fs }) => {
+    const transformer = new CodeTransformer(fs.baseUrl)
+
+    await transformer.updateRcFile((rcFile) =>
+      rcFile.addDefaultImport('@adonisjs/inertia', 'indexPages')
+    )
+
+    const file = await fs.contents('adonisrc.ts')
+    assert.snapshot(file).match()
+  })
+})
+
+test.group('Code Transformer | addNamedImport', (group) => {
+  group.each.setup(async ({ context }) => setupFakeAdonisproject(context.fs))
+
+  test('add named import to the assembler file', async ({ assert, fs }) => {
+    const transformer = new CodeTransformer(fs.baseUrl)
+
+    await transformer.updateRcFile((rcFile) =>
+      rcFile.addNamedImport('@adonisjs/inertia', ['indexPages'])
+    )
+
+    const file = await fs.contents('adonisrc.ts')
+    assert.snapshot(file).match()
+  })
 })


### PR DESCRIPTION

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull-request adds the ability to add raw assembler hooks to the rcFile

```ts
codemods.updateRcFile((rcFile) => {
  rcFile.addNamedImport('@adonisjs/vite', ['indexPages'])
  rcFile.addAssemblerHook('init', 'indexPages()', true)
})
```

```ts
import { indexPages } from '@adonisjs/vite'

export default defineConfig({
  hooks: {
    init: [indexPages()]
  }
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
