### PR TITLE
feat: allow custom tsconfig path for bundle

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -141,12 +141,14 @@ export class Bundler {
   /**
    * Runs tsc command to build the source.
    */
-  async #runTsc(outDir: string): Promise<boolean> {
+  async #runTsc(args: { outDir: string; project?: string }): Promise<boolean> {
     try {
       await run(this.cwd, {
         stdio: 'inherit',
         script: 'tsc',
-        scriptArgs: ['--outDir', outDir],
+        scriptArgs: Object.entries(args).flatMap(([key, value]) =>
+          value ? [`--${key}`, value] : []
+        ),
       })
       return true
     } catch {
@@ -211,13 +213,17 @@ export class Bundler {
    * @example
    * const success = await bundler.bundle(true, 'npm')
    */
-  async bundle(stopOnError: boolean = true, client?: SupportedPackageManager): Promise<boolean> {
+  async bundle(
+    stopOnError: boolean = true,
+    client?: SupportedPackageManager,
+    options: { tsconfigPath?: string } = {}
+  ): Promise<boolean> {
     this.packageManager = client ?? (await this.#detectPackageManager()) ?? 'npm'
 
     /**
      * Step 1: Parse config file to get the build output directory
      */
-    const config = parseConfig(this.cwd, this.#ts)
+    const config = parseConfig(this.cwd, this.#ts, options.tsconfigPath)
     if (!config) {
       return false
     }
@@ -251,7 +257,10 @@ export class Bundler {
      * Step 5: Build typescript source code
      */
     this.ui.logger.info('compiling typescript source', { suffix: 'tsc' })
-    const buildCompleted = await this.#runTsc(outDir)
+    const buildCompleted = await this.#runTsc({
+      outDir,
+      project: options.tsconfigPath,
+    })
     await this.#createAceFile(outDir)
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,10 +48,11 @@ const DEFAULT_NODE_ARGS = ['--import=@poppinss/ts-exec', '--enable-source-maps']
  */
 export function parseConfig(
   cwd: URL | string,
-  ts: typeof tsStatic
+  ts: typeof tsStatic,
+  path = 'tsconfig.json'
 ): tsStatic.ParsedCommandLine | undefined {
   const cwdPath = typeof cwd === 'string' ? cwd : fileURLToPath(cwd)
-  const configFile = join(cwdPath, 'tsconfig.json')
+  const configFile = join(cwdPath, path)
   debug('parsing config file "%s"', configFile)
 
   let hardException: null | tsStatic.Diagnostic = null

--- a/tests/bundler.spec.ts
+++ b/tests/bundler.spec.ts
@@ -376,4 +376,38 @@ test.group('Bundler', () => {
       "
     `)
   })
+
+  test('use custom tsconfig for build', async ({ assert, fs }) => {
+    await Promise.all([
+      fs.create(
+        'tsconfig.build.json',
+        JSON.stringify({
+          compilerOptions: {
+            outDir: 'build',
+            skipLibCheck: true,
+            target: 'ESNext',
+            module: 'NodeNext',
+            lib: ['ESNext'],
+          },
+        })
+      ),
+      fs.create('adonisrc.ts', 'export default {}'),
+      fs.create('index.ts', 'export default function main() {}'),
+      fs.createJson('package.json', { type: 'module' }),
+      fs.create('package-lock.json', '{}'),
+    ])
+
+    const bundler = new Bundler(fs.baseUrl, ts, {})
+    bundler.ui.switchMode('raw')
+    await bundler.bundle(true, 'npm', {
+      tsconfigPath: './tsconfig.build.json',
+    })
+
+    await Promise.all([
+      assert.fileExists('./build/adonisrc.js'),
+      assert.fileExists('./build/index.js'),
+      assert.fileExists('./build/package.json'),
+      assert.fileExists('./build/package-lock.json'),
+    ])
+  })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds option to provide custom `tsconfig.json` path when building the project.

This is useful when you want to exclude some files from bundle for example.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
