### PR TITLE
fix: read tsconfig without the TypeScript compiler API

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ts-morph": "^28.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0 || ^6.0.0"
+    "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "author": "virk,adonisjs",
   "license": "MIT",

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -196,6 +196,11 @@ export class Bundler {
       await import('./bin/console.js')
     `)
 
+    /**
+     * tsc emits nothing when it rejects the config itself (say "include"
+     * matches no files), so the output directory may not exist at this point.
+     */
+    await fs.mkdir(outDir, { recursive: true })
     await fs.writeFile(aceFileLocation, aceFileContent)
     this.ui.logger.info('created ace file', { suffix: this.#getRelativeName(aceFileLocation) })
   }

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -18,7 +18,7 @@ import { join, relative } from 'node:path/posix'
 import { detectPackageManager } from '@antfu/install-pkg'
 
 import type { BundlerOptions } from './types/common.ts'
-import { run, parseConfig, copyFiles, loadHooks } from './utils.ts'
+import { run, readTsConfig, copyFiles, loadHooks } from './utils.ts'
 import { type HookParams, type BundlerHooks, type CommonHooks } from './types/hooks.ts'
 import { type SupportedPackageManager } from './types/code_transformer.ts'
 import { IndexGenerator } from './index_generator/main.ts'
@@ -64,11 +64,6 @@ export const SUPPORTED_PACKAGE_MANAGERS: {
  */
 export class Bundler {
   /**
-   * Reference to the TypeScript module
-   */
-  #ts: typeof tsStatic
-
-  /**
    * Hooks to execute custom actions during the build process
    */
   #hooks!: Hooks<
@@ -113,14 +108,16 @@ export class Bundler {
    * Create a new bundler instance
    *
    * @param cwd - The current working directory URL
-   * @param ts - TypeScript module reference
+   * @param _ts - TypeScript module reference. No longer used: the bundler reads
+   *   the tsconfig through "get-tsconfig" and shells out to the "tsc" binary
+   *   for the actual compile. Kept so the constructor signature stays
+   *   backwards compatible.
    * @param options - Bundler configuration options
    */
-  constructor(cwd: URL, ts: typeof tsStatic, options: BundlerOptions) {
+  constructor(cwd: URL, _ts: typeof tsStatic, options: BundlerOptions) {
     this.cwd = cwd
     this.options = options
     this.cwdPath = string.toUnixSlash(fileURLToPath(this.cwd))
-    this.#ts = ts
   }
 
   /**
@@ -221,10 +218,11 @@ export class Bundler {
     this.packageManager = client ?? (await this.#detectPackageManager()) ?? 'npm'
 
     /**
-     * Step 1: Parse config file to get the build output directory
+     * Step 1: Read config file to get the build output directory
      */
-    const config = parseConfig(this.cwd, this.#ts, options.tsconfigPath)
-    if (!config) {
+    const tsConfig = readTsConfig(this.cwdPath, options.tsconfigPath)
+    if (!tsConfig) {
+      this.ui.logger.error('unable to read the tsconfig file')
       return false
     }
 
@@ -244,7 +242,15 @@ export class Bundler {
     /**
      * Step 3: Cleanup existing build directory (if any)
      */
-    const outDir = config.options.outDir || fileURLToPath(new URL('build/', this.cwd))
+    /**
+     * "get-tsconfig" hands back the outDir exactly as authored (say "./build"),
+     * whereas the compiler API used to resolve it for us. Everything below —
+     * the rm, the ace file write, the relative name for logging — expects an
+     * absolute path, so resolve it against the project root.
+     */
+    const outDir = fileURLToPath(
+      new URL(tsConfig.config.compilerOptions?.outDir ?? 'build/', this.cwd)
+    )
     this.ui.logger.info('cleaning up output directory', { suffix: this.#getRelativeName(outDir) })
     await this.#cleanupBuildDirectory(outDir)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,8 +93,16 @@ export function parseConfig(
   return parsedConfig
 }
 
-export function readTsConfig(cwd: string): TsConfigResult | null {
-  const tsConfigPath = join(cwd, 'tsconfig.json')
+/**
+ * Reads and parses the tsconfig file without going through the TypeScript
+ * compiler API.
+ *
+ * @param cwd - The project root directory path
+ * @param path - Config file to read, relative to "cwd" (or an absolute path)
+ * @returns The parsed config, or null when it cannot be read
+ */
+export function readTsConfig(cwd: string, path: string = 'tsconfig.json'): TsConfigResult | null {
+  const tsConfigPath = isAbsolute(path) ? path : join(cwd, path)
   debug('reading config file from location "%s"', tsConfigPath)
 
   try {

--- a/tests/bundler.spec.ts
+++ b/tests/bundler.spec.ts
@@ -410,4 +410,70 @@ test.group('Bundler', () => {
       assert.fileExists('./build/package-lock.json'),
     ])
   })
+
+  test('build without touching the typescript module', async ({ assert, fs }) => {
+    await Promise.all([
+      fs.create(
+        'tsconfig.json',
+        JSON.stringify({ compilerOptions: { outDir: 'build', skipLibCheck: true } })
+      ),
+      fs.create('adonisrc.ts', 'export default {}'),
+      fs.create('package.json', '{}'),
+      fs.create('package-lock.json', '{}'),
+    ])
+
+    /**
+     * TypeScript 7 dropped the programmatic compiler API, so reaching for any
+     * property on the module is what used to blow the build up with
+     * "ts.getParsedCommandLineOfConfigFile is not a function".
+     */
+    const unusableTs = new Proxy(
+      {},
+      {
+        get(_, property) {
+          throw new Error(`Bundler read "${String(property)}" off the typescript module`)
+        },
+      }
+    ) as unknown as typeof ts
+
+    const bundler = new Bundler(fs.baseUrl, unusableTs, { suites: [], metaFiles: [] })
+    bundler.ui.switchMode('raw')
+
+    assert.isTrue(await bundler.bundle(true, 'npm'))
+    await assert.fileExists('./build/package.json')
+  })
+
+  test('resolve a nested outDir against the project root', async ({ assert, fs }) => {
+    await Promise.all([
+      fs.create(
+        'tsconfig.json',
+        JSON.stringify({ compilerOptions: { outDir: './dist/server', skipLibCheck: true } })
+      ),
+      fs.create('adonisrc.ts', 'export default {}'),
+      fs.create('package.json', '{}'),
+      fs.create('package-lock.json', '{}'),
+    ])
+
+    const bundler = new Bundler(fs.baseUrl, ts, { suites: [], metaFiles: [] })
+    bundler.ui.switchMode('raw')
+    await bundler.bundle(true, 'npm')
+
+    await Promise.all([
+      assert.fileExists('./dist/server/package.json'),
+      assert.fileExists('./dist/server/adonisrc.js'),
+      assert.fileExists('./dist/server/ace.js'),
+    ])
+  })
+
+  test('fail gracefully when the tsconfig file is missing', async ({ assert, fs }) => {
+    await Promise.all([
+      fs.create('adonisrc.ts', 'export default {}'),
+      fs.create('package.json', '{}'),
+    ])
+
+    const bundler = new Bundler(fs.baseUrl, ts, { suites: [], metaFiles: [] })
+    bundler.ui.switchMode('raw')
+
+    assert.isFalse(await bundler.bundle(true, 'npm'))
+  })
 })

--- a/tests/bundler.spec.ts
+++ b/tests/bundler.spec.ts
@@ -476,4 +476,27 @@ test.group('Bundler', () => {
 
     assert.isFalse(await bundler.bundle(true, 'npm'))
   })
+
+  test('return false when tsc rejects the config itself', async ({ assert, fs }) => {
+    await Promise.all([
+      /**
+       * "include" matches nothing, so tsc bails with TS18003 and emits no
+       * output at all — meaning the outDir never gets created.
+       */
+      fs.create(
+        'tsconfig.json',
+        JSON.stringify({
+          compilerOptions: { outDir: 'build', skipLibCheck: true },
+          include: ['src/**/*'],
+        })
+      ),
+      fs.create('adonisrc.ts', 'export default {}'),
+      fs.create('package.json', '{}'),
+    ])
+
+    const bundler = new Bundler(fs.baseUrl, ts, { suites: [], metaFiles: [] })
+    bundler.ui.switchMode('raw')
+
+    assert.isFalse(await bundler.bundle(true, 'npm'))
+  })
 })


### PR DESCRIPTION
Takes a shot at #97.

Building with `typescript@7` currently blows up:

```
TypeError: ts.getParsedCommandLineOfConfigFile is not a function
  at parseConfig (.../assembler/build/virtual_file_system-BFFXmame.js:61:26)
```

`ts.getParsedCommandLineOfConfigFile` was deprecated in TypeScript 6 and is gone in 7, which dropped the programmatic compiler API entirely. Its export map is now just `lib/version.cjs` plus `./unstable/*`, so anything reaching into `ts.*` is out of luck until the new API lands in 7.1.

## The nice part

`Bundler.bundle()` was calling `parseConfig()` and then using **exactly one field** off the result:

```ts
const config = parseConfig(this.cwd, this.#ts, options.tsconfigPath)
// ...
const outDir = config.options.outDir || fileURLToPath(new URL('build/', this.cwd))
```

Everything else got thrown away. And `readTsConfig()` — the `get-tsconfig` based reader with no compiler API in sight — was already sitting right there in the same file, already used by `DevServer` and `TestRunner`. `parseConfig()` is even marked `@deprecated While we are experimenting with the readTsConfig method`, so this is really just finishing that experiment for the one caller that hadn't moved over.

`parseConfig()` itself stays exported and untouched, along with its tests.

## Two things that needed care

> [!IMPORTANT]
> A straight swap of the two calls looks right but quietly breaks two things. Both are covered below.

**1. `tsconfigPath` would have been silently dropped.** `parseConfig()` took a path argument; `readTsConfig()` hardcoded `tsconfig.json`. So `readTsConfig()` gained an optional one:

```ts
export function readTsConfig(cwd: string, path: string = 'tsconfig.json'): TsConfigResult | null {
  const tsConfigPath = isAbsolute(path) ? path : join(cwd, path)
```

Without this the existing `use custom tsconfig for build` test fails.

**2. `outDir` comes back unresolved.** This one is sneakier — the two readers genuinely disagree:

```ts
// tsconfig: { "compilerOptions": { "outDir": "./build" } }

parseConfig(...).options.outDir              // "/abs/path/to/project/build"
readTsConfig(...).config.compilerOptions.outDir  // "./build"
```

`get-tsconfig` hands back the string as authored. That matters because everything downstream assumes absolute:

```ts
await fs.rm(outDir, { recursive: true, force: true })   // relative → resolves against process.cwd()
const aceFileLocation = join(outDir, 'ace.js')
relative(this.cwdPath, outDir)                          // for the log line
```

A relative `outDir` reaching `fs.rm` felt like something worth not shipping, so it's resolved against the project root:

```ts
const outDir = fileURLToPath(
  new URL(tsConfig.config.compilerOptions?.outDir ?? 'build/', this.cwd)
)
```

Reusing the `new URL(..., this.cwd)` idiom the fallback already used, so absolute values in tsconfig keep working too.

## Everything else

`#ts` was the only thing left using the module, so the private field is gone. The constructor still takes it (renamed `_ts`) so the signature stays compatible for `@adonisjs/core` and anyone else constructing a `Bundler` directly.

Also added an error log on the `null` branch. `parseConfig()` printed diagnostics before returning `undefined`; `readTsConfig()` just returns `null`, so without this a bad tsconfig would fail the build in total silence. Matches what `DevServer` and `TestRunner` already do.

## Tests

Four new ones in `tests/bundler.spec.ts`:

| Test | What it pins down |
| --- | --- |
| `build without touching the typescript module` | Passes a `Proxy` that throws on **any** property access, so the build fails loudly if anything reaches for `ts.*` again |
| `resolve a nested outDir against the project root` | `outDir: './dist/server'` actually lands there |
| `fail gracefully when the tsconfig file is missing` | The `null` branch returns `false` instead of throwing |
| `return false when tsc rejects the config itself` | The `ENOENT` regression described at the bottom |

Suite goes 247 → 251 passing. The one failing test (`dev_server`, `expected <port> to equal 3333`) fails the same way on a clean checkout of `8.x` here — something local was holding 3333.

`eslint .` is clean. `tsc --noEmit` reports the same 7 errors before and after — all in `#detectPackageManager` and the picomatch option types, none related to this change.

## Worth a second opinion

The commenter on #97 suggested skipping tsconfig entirely and just defaulting to `build/` or taking a flag. That'd be a nicer end state, but it changes behaviour for anyone with a custom `outDir`, so this sticks to keeping things as they are. Happy to go the other way if you'd prefer.

Haven't touched the `ts` parameter in the public constructor signature either — dropping it is a clean break for a major, and figured that's your call rather than mine.

## One behaviour change, and the bug it shook out

> [!WARNING]
> This is the only place where the two readers genuinely disagree, and it needed a follow-up fix. Flagging it properly rather than leaving it to be discovered.

`parseConfig()` validated the config through the compiler, so a tsconfig that tsc rejects outright — `include` matching no files (`TS18003`), a config file that isn't there (`TS5083`) — got caught at **step 1** and the build bailed before the compile ever started.

`get-tsconfig` doesn't do that. It parses the file, resolves `extends`, and hands it back. It has no opinion on whether the config is *semantically* usable. So those failures now arrive later, from tsc itself during the compile step.

The build still fails either way, and tsc's own diagnostics are arguably the better error message. But the shift exposed a latent crash:

```ts
const buildCompleted = await this.#runTsc({ outDir, project: options.tsconfigPath })
await this.#createAceFile(outDir)   // <- outDir may not exist

if (!buildCompleted && stopOnError) { /* cleanup, return false */ }
```

When tsc rejects the config it emits **nothing**, so `outDir` is never created and `#createAceFile` threw `ENOENT` instead of `bundle()` returning `false`. It never showed up before because `parseConfig()` intercepted exactly those configs first. Type errors don't trigger it — tsc still emits in that case, which is why the existing `do not build when there are type errors` test stayed green.

Fixed by making the ace file write ensure its own directory:

```ts
await fs.mkdir(outDir, { recursive: true })
await fs.writeFile(aceFileLocation, aceFileContent)
```

That covers `--ignore-ts-errors` too, which otherwise hits the same path with `stopOnError` off. Verified against a real project with `include: ["src/**/*"]` and no `src/` — `bundle()` now returns `false` cleanly instead of throwing — and pinned with a `return false when tsc rejects the config itself` test.
