### PR TITLE
perf: speed up index generation sorting

### DIFF
--- a/src/virtual_file_system.ts
+++ b/src/virtual_file_system.ts
@@ -13,7 +13,6 @@ import { relative } from 'node:path/posix'
 import lodash from '@poppinss/utils/lodash'
 import string from '@poppinss/utils/string'
 import { readFile } from 'node:fs/promises'
-import { naturalSort } from '@poppinss/utils'
 import { Lang, parse, type SgNode } from '@ast-grep/napi'
 import picomatch, { type PicomatchOptions, type Matcher } from 'picomatch'
 
@@ -23,6 +22,7 @@ import { type RecursiveFileTree, type VirtualFileSystemOptions } from './types/c
 
 const BYPASS_FN = <T>(input: T) => input
 const DEFAULT_GLOB = ['**/!(*.d).ts', '**/*.tsx', '**/*.js']
+const NATURAL_SORT = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare
 
 /**
  * Virtual file system for managing and tracking files with AST parsing capabilities.
@@ -105,7 +105,7 @@ export class VirtualFileSystem {
 
     const filesList = await crawler.crawl(this.#source).withPromise()
     debug('scanned files %O', filesList)
-    const sortedFiles = filesList.sort(naturalSort)
+    const sortedFiles = filesList.sort(NATURAL_SORT)
     this.#files.clear()
 
     for (let filePath of sortedFiles) {

--- a/tests/virtual_file_system.spec.ts
+++ b/tests/virtual_file_system.spec.ts
@@ -44,6 +44,36 @@ test.group('Virtual file system', () => {
     )
   })
 
+  test('naturally sort file paths', async ({ fs, assert }) => {
+    await fs.create('controllers/item_10.ts', '')
+    await fs.create('controllers/item_2.ts', '')
+    await fs.create('controllers/item_01.ts', '')
+    await fs.create('controllers/item_1.ts', '')
+    await fs.create('controllers/café.ts', '')
+    await fs.create('controllers/cafe.ts', '')
+    await fs.create('controllers/alpha.ts', '')
+    await fs.create('controllers/Alpha.ts', '')
+    await fs.create('controllers/nested_10/item_2.ts', '')
+    await fs.create('controllers/nested_2/item_10.ts', '')
+
+    const source = string.toUnixSlash(join(fs.basePath, 'controllers'))
+    const vfs = new VirtualFileSystem(source)
+    await vfs.scan()
+
+    assert.deepEqual(Object.keys(vfs.asList()), [
+      'Alpha',
+      'alpha',
+      'cafe',
+      'café',
+      'item_01',
+      'item_1',
+      'item_2',
+      'item_10',
+      'nested_2/item_10',
+      'nested_10/item_2',
+    ])
+  })
+
   test('list files as a tree', async ({ fs, assert }) => {
     await setupFakeAdonisproject(fs)
     await createControllers()


### PR DESCRIPTION
Hey! :wave:

`VirtualFileSystem.scan` currently uses `naturalSort`, which calls `localeCompare` with collation options for every comparison. Sorting becomes the main CPU cost when generating indexes with hundreds or thousands of files.

This PR creates one `Intl.Collator` with the same options and reuses its bound comparator. It preserves the existing natural, case-insensitive, and accent-insensitive order. A focused test covers numbers, leading zeros, casing, accents, and nested directories.

### Benchmark

Node.js 24.20.0 using the public `IndexGenerator` API, with 12 independent before/after process pairs and alternating execution order.

| Files | Before | After | Change |
|---:|---:|---:|---:|
| 10 | 0.750 ms | 0.628 ms | -16.3% |
| 25 | 1.877 ms | 1.435 ms | -23.5% |
| 50 | 3.266 ms | 2.150 ms | -34.2% |
| 100 | 5.158 ms | 2.756 ms | -46.6% |
| 1,000 | 34.575 ms | 10.908 ms | -68.5% |
| 5,000 | 184.340 ms | 51.217 ms | -72.2% |

At 1,000 files, the CPU profile dropped from 2,120 ms to 673 ms across 60 generations.

The old and new comparators produced identical results across 4,206,601 comparisons and 100 shuffled stable sorts. A generated 1,000-file index was also byte-identical.

### Validation

- 262 tests passed
- Typecheck passed
- ESLint passed
