### PR TITLE
perf: speed up route validator scanning

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -174,7 +174,9 @@ export function nodeToPlainText(node: SgNode) {
   function toText(one: SgNode) {
     const children = one.children()
     if (!children.length) {
-      out.push(one.text())
+      if (!one.is('comment')) {
+        out.push(one.text())
+      }
     } else {
       children.forEach((child) => toText(child))
     }
@@ -205,18 +207,36 @@ export function nodeToPlainText(node: SgNode) {
  * validatorArgs.forEach(arg => console.log('Validator argument:', arg.text()))
  */
 export function inspectMethodArguments(node: SgNode, methodCalls: string[]): SgNode[] {
-  const matchingExpressions = node.findAll({
-    rule: {
-      any: methodCalls.map((methodCall) => {
-        return {
-          pattern: {
-            context: `${methodCall}($$$ARGUMENTS)`,
-            selector: 'call_expression',
-          },
-        }
-      }),
-    },
+  const exactMethodCalls = new Set<string>()
+  const receiverMethodCalls: string[] = []
+
+  methodCalls.forEach((methodCall) => {
+    const separator = methodCall.indexOf('.')
+    if (methodCall.startsWith('$') && separator !== -1) {
+      receiverMethodCalls.push(methodCall.slice(separator + 1))
+    } else {
+      exactMethodCalls.add(methodCall)
+    }
   })
+
+  const matchingExpressions = node
+    .findAll({ rule: { kind: 'call_expression' } })
+    .filter((expression) => {
+      const functionNode = expression.field('function')
+      if (!functionNode) {
+        return false
+      }
+      const functionName = nodeToPlainText(functionNode)
+
+      return (
+        exactMethodCalls.has(functionName) ||
+        receiverMethodCalls.some((methodCall) => {
+          return (
+            functionName.endsWith(`.${methodCall}`) && !functionName.endsWith(`?.${methodCall}`)
+          )
+        })
+      )
+    })
 
   return matchingExpressions.flatMap((matchingExpression) => {
     return matchingExpression.findAll({ rule: { kind: 'arguments' } })

--- a/tests/helpers/inspect_method_arguments.spec.ts
+++ b/tests/helpers/inspect_method_arguments.spec.ts
@@ -76,6 +76,36 @@ test.group('Inspect method arguments', () => {
       }`,
         output: ['createCarValidator', 'createVehicleValidator'],
       },
+      {
+        input: `class UsersController {
+        async store(ctx: HttpContext) {
+          await ctx.request.tryValidateUsing(admin.createUserValidator)
+          await this.ctx.request.validateUsing(createUserValidator)
+        }
+      }`,
+        output: ['admin.createUserValidator', 'createUserValidator'],
+      },
+      {
+        input: `class UsersController {
+        async store() {
+          await request /* request comment */ . validateUsing(
+            factory(createUserValidator)
+          )
+          await vine.tryValidate(user.createUserValidator)
+        }
+      }`,
+        output: ['factory', 'createUserValidator', 'user.createUserValidator'],
+      },
+      {
+        input: `class UsersController {
+        async store(ctx: HttpContext) {
+          await request?.validateUsing(optionalValidator)
+          await ctx?.request.validateUsing(optionalContextValidator)
+          await validator.validate(request.all())
+        }
+      }`,
+        output: [],
+      },
     ])
     .run(({ assert }, { input, output }) => {
       const root = parse(Lang.TypeScript, input).root()
@@ -87,7 +117,11 @@ test.group('Inspect method arguments', () => {
 
       const validatorArguments = inspectMethodArguments(storeMethod, [
         'request.validateUsing',
+        'request.tryValidateUsing',
+        '$CTX.request.validateUsing',
+        '$CTX.request.tryValidateUsing',
         'vine.validate',
+        'vine.tryValidate',
       ]).map((node) => {
         return nodeToPlainText(
           node.find({ rule: { any: [{ kind: 'identifier' }, { kind: 'member_expression' }] } })!


### PR DESCRIPTION
Hey! :wave:

Route validator scanning currently builds six ast-grep patterns for every controller method it inspects. This repeated pattern construction becomes a visible CPU cost as the route count grows.

This PR traverses call expressions once and compares their function references directly. It preserves the existing `$CTX` receiver behavior, ignores comments inside member expressions, and does not introduce optional chaining matches that the previous ast-grep patterns rejected.

Focused tests cover comments, nested calls, `tryValidateUsing`, `$CTX`, VineJS calls, member references, optional chaining, and direct validator usage.

### Benchmark

Node.js 24.20.0 using the public `RoutesScanner.scan` API. The fixture uses five actions per controller and distributes the six supported validation syntaxes across routes.

Each variant ran in 4 independent processes with 2 warmups and 15 measured scans per process. Execution order alternated between variants and GC ran before every measurement.

| Routes | Before | After | Change |
|---:|---:|---:|---:|
| 50 | 27.01 ms | 22.56 ms | -16.5% |
| 125 | 60.60 ms | 50.53 ms | -16.6% |
| 250 | 120.36 ms | 95.11 ms | -21.0% |
| 500 | 242.02 ms | 193.48 ms | -20.1% |

At 500 routes, the change saves 48.54 ms per complete scan.

Across ten 500-route scans, the CPU profile dropped from 3,330 to 2,503 samples. Samples attributed directly to `inspectMethodArguments` dropped from 835 to 85.

### Validation

- 267 tests passed on Node.js 24
- Typecheck passed
- ESLint passed
- `git diff --check` passed
